### PR TITLE
Add missing pytz dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'requests>=2.24.0',
         'sentry_sdk>=0.13.5',
         'yt_dlp>=2021.10.22',
+        'pytz>=2023.3',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Before this fix, the docker container did not work:

```python
Traceback (most recent call last):
  File "/usr/local/bin/moodle-dl", line 5, in <module>
    from moodle_dl.main import main
  File "/usr/local/lib/python3.11/site-packages/moodle_dl/main.py", line 23, in <module>
    from moodle_dl.cli import (
  File "/usr/local/lib/python3.11/site-packages/moodle_dl/cli/__init__.py", line 7, in <module>
    from moodle_dl.cli.notifications_wizard import NotificationsWizard
  File "/usr/local/lib/python3.11/site-packages/moodle_dl/cli/notifications_wizard.py", line 3, in <module>
    from aioxmpp.errors import StanzaError, UserError
  File "/usr/local/lib/python3.11/site-packages/aioxmpp/__init__.py", line 101, in <module>
    from .errors import (  # NOQA
  File "/usr/local/lib/python3.11/site-packages/aioxmpp/errors.py", line 90, in <module>
    from . import xso, i18n, structs
  File "/usr/local/lib/python3.11/site-packages/aioxmpp/xso/__init__.py", line 588, in <module>
    from .types import (  # NOQA: F401
  File "/usr/local/lib/python3.11/site-packages/aioxmpp/xso/types.py", line 42, in <module>
    import pytz
ModuleNotFoundError: No module named 'pytz'
```