### PR TITLE
Fix error raised when ext is None, since python cannot evaulate len(None)

### DIFF
--- a/moodle_dl/utils.py
+++ b/moodle_dl/utils.py
@@ -457,7 +457,10 @@ class PathTools:
                 name = PathTools.truncate_name(name, max_length)
             else:
                 stem, ext = PathTools.get_file_stem_and_ext(name)
-                ext_len = len(ext)
+                if ext is not None:
+                    ext_len = len(ext)
+                else:
+                    ext_len = 0
                 if ext is None or ext_len == 0 or ext_len > 20:
                     # extensions longer then 20 characters are probably no extensions
                     name = PathTools.truncate_name(name, max_length)


### PR DESCRIPTION
Hello there

I found out, that in the code `ext` max be None, which is foreseen by the next if statement. But the statement len(ext) is evaluated before that if statement. This raises an error which aborts Moodle-DL. 

I fix that in this pull request with checking if `ext` is not None and then evaluete the lenght of it. Otherwise I set the length to 0(which is not used but for completness I added it) .