### PR TITLE
Add warning to moodle_service.py

### DIFF
--- a/moodle_dl/moodle/moodle_service.py
+++ b/moodle_dl/moodle/moodle_service.py
@@ -48,6 +48,7 @@ class MoodleService:
         splitted = address.split('token=')
 
         if len(splitted) < 2:
+            print("this might not be the correct url. Did you maybe only paste the token instead of the whole url?")
             return None
 
         decoded = str(base64.b64decode(splitted[1]))


### PR DESCRIPTION
It happend twice to me that I accidentally pasted only the token instead of the whole url. Maybe adding this note helps with the setup?